### PR TITLE
added argument to omit builtin CPTs

### DIFF
--- a/pmpro-cpt.php
+++ b/pmpro-cpt.php
@@ -201,7 +201,12 @@ function pmprocpt_options_page() {
 
 	// get options
 	$options = get_option( 'pmprocpt_options' );
-	$pmprocpt_cpts = get_post_types( array( '_builtin' => false ), 'names' );
+	$pmprocpt_cpts = get_post_types(
+		array(
+			'public'   => true,
+			'_builtin' => false,
+		), 'names'
+	);
 	$cpt_selections = pmprocpt_getCPTs();
 ?>
 <div class="wrap">

--- a/pmpro-cpt.php
+++ b/pmpro-cpt.php
@@ -201,7 +201,7 @@ function pmprocpt_options_page() {
 
 	// get options
 	$options = get_option( 'pmprocpt_options' );
-	$pmprocpt_cpts = get_post_types( '', 'names' );
+	$pmprocpt_cpts = get_post_types( array( '_builtin' => false ), 'names' );
 	$cpt_selections = pmprocpt_getCPTs();
 ?>
 <div class="wrap">


### PR DESCRIPTION
Currently the CPTs array includes builtin Post Types that aren't relevant for PMPro:

![Alt text](https://monosnap.com/image/cWsDP239A5kcDQT3X27yXUpwfcjQIz.png)

adding `array( '_builtin' => false )` to the arguments array leaves only CPTs that will make sense to users

![Alt text](https://monosnap.com/image/NvtQqLbdKtywZTAPos4jL5GoqSDRPo.png)
