### PR TITLE
Updating to use `pmpro_restrictable_post_types` filter

### DIFF
--- a/pmpro-cpt.php
+++ b/pmpro-cpt.php
@@ -20,6 +20,9 @@ add_action( 'init', 'pmprocpt_load_plugin_text_domain');
 /**
  * pmprocpt_page_meta_wrapper Wrapper to add meta boxes
  *
+ * This is legacy functionality from before the `pmpro_restrictable_post_types` filter was added and will be removed in a future version.
+ * This function should not be called if running a PMPro version supporting that filter. See `pmprocpt_init()` below for more info.
+ *
  * @return [type] [description]
  */
 function pmprocpt_page_meta_wrapper() {
@@ -79,11 +82,35 @@ function pmprocpt_getCPTs() {
 }
 
 /**
+ * Filter the post types that can be restricted.
+ *
+ * @param array $post_types An array of post type names.
+ * @return array An array of post type names.
+ */
+function pmprocpt_pmpro_restrictable_post_types( $post_types ) {
+	$selected_cpts = pmprocpt_getCPTs();
+	if ( ! empty( $selected_cpts ) ) {
+		$post_types = array_merge( $post_types, $selected_cpts );
+	}
+	return $post_types;
+}
+add_filter( 'pmpro_restrictable_post_types', 'pmprocpt_pmpro_restrictable_post_types' );
+
+/**
  * pmprocpt_init Add Settings Page to WordPress admin.
+ *
+ * This is legacy functionality from before the `pmpro_restrictable_post_types` filter was added and will be removed in a future version.
  *
  * @return [type] [description]
  */
 function pmprocpt_init() {
+	// Check if the PMPro_REST_API_Routes::pmpro_rest_api_get_post_restrictions() method exists.
+	// If so, we are running a PMPro version that supports the `pmpro_restrictable_post_types` filter and
+	// we don't need to manually add meta boxes to CPTs.
+	if ( class_exists( 'PMPro_REST_API_Routes' ) && method_exists( 'PMPro_REST_API_Routes', 'pmpro_rest_api_get_post_restrictions' ) ) {
+		return;
+	}
+
 	if ( is_admin() ) {
 		add_action( 'admin_menu', 'pmprocpt_page_meta_wrapper' );
 	}


### PR DESCRIPTION
This PR updates the Add On to use the `pmpro_restrictable_post_types` filter implemented in this core PMPro PR here and should only be merged once we are confident that the core PR will be released with the filter name `pmpro_restrictable_post_types` and a new method `PMPro_REST_API_Routes::pmpro_rest_api_get_post_restrictions()`:
https://github.com/strangerstudios/paid-memberships-pro/pull/2445

The benefits of this change are:
- Simplified code for adding restriction settings to CPTs
- Taking advantage of using block editor panels instead of metaboxes, as per the core PR

As this PR and the core PR are coded, sites will continue to work as expected with neither plugin updated, only core update, only this Add On update, or with both updated.